### PR TITLE
[SNG-001] Remove `embedding` base scope

### DIFF
--- a/documents/001-base-scope.md
+++ b/documents/001-base-scope.md
@@ -70,12 +70,6 @@ of the following three first-level sub-scopes:
   Text in such syntaxes usually has special meaning,
   is not spell-checked and auto completions are enabled.
 
-- `embedding` is a special use case for syntaxes
-   that are embedded later into the file.
-   The effect of an `embedding` scope is mostly transparent
-   and the text vs. source decision
-   is deferred to the following scope name.
-
 The second sub-scope level of the scope name
 should be the syntax name itself
 in lower-case alphanumeric characters.


### PR DESCRIPTION
Fixes #6

Reasons:

1. PHP is the only Default Syntax which uses `embedding.php` as
   top-level scope.

2. PHP should better use `text.html.php` as it is more likely a dialect
   or templating extension of text.html.basic

   This is what ASP package does. It uses `text.html.asp` as top-level
   scope to denote the mix of html and basic syntax.

3. The current description expresses exactly the opposite of how this
   scope is used by PHP.